### PR TITLE
feat(mapbox): update to mapbox api v6

### DIFF
--- a/src/geocoder/mapbox.js
+++ b/src/geocoder/mapbox.js
@@ -36,7 +36,7 @@ export class MapBoxGeocoder extends AbstractGeocoder {
    * @param {number} [options.limit=5]
    * @param {string} [options.language]
    */
-  constructor (adapter, options = { apiKey: '' }) {
+  constructor(adapter, options = { apiKey: '' }) {
     // @ts-ignore
     super(adapter, options)
 
@@ -51,28 +51,27 @@ export class MapBoxGeocoder extends AbstractGeocoder {
     this.params = params
   }
 
-  get endpoint () {
-    return 'https://api.mapbox.com/geocoding/v5/mapbox.places'
+  get endpoint() {
+    return 'https://api.mapbox.com/search/geocode/v6'
   }
 
   /**
    * @param {string|MapBoxForwardQuery} query
    * @returns {Promise<object>}
    */
-  async _forward (query) {
-    let params = this.params
+  async _forward(query) {
     let searchtext = query
+    let params
 
     if (typeof query !== 'string' && query.address) {
       const { address, ...other } = query
-      searchtext = address
-      params = { ...params, ...other }
+      searchtext = encodeURIComponent(String(address))
+      params = { q: searchtext, ...this.params, ...other }
     }
 
-    const url = this.createUrl(
-      `${this.endpoint}/${encodeURIComponent(String(searchtext))}.json`,
-      params
-    )
+    params = { q: encodeURIComponent(String(searchtext)), ...this.params }
+
+    const url = this.createUrl(`${this.endpoint}/forward`, params)
 
     const res = await this.adapter(url)
     if (res.status !== 200) {
@@ -90,14 +89,11 @@ export class MapBoxGeocoder extends AbstractGeocoder {
    * @param {MapBoxReverseQuery} query
    * @returns {Promise<object>}
    */
-  async _reverse (query) {
+  async _reverse(query) {
     const { lat, lng, ...other } = query
-    const params = { ...this.params, ...other }
+    const params = { longitude: lng, latitude: lat, ...other, ...this.params }
 
-    const url = this.createUrl(
-      `${this.endpoint}/${encodeURIComponent(`${lng},${lat}`)}.json`,
-      params
-    )
+    const url = this.createUrl(`${this.endpoint}/reverse`, params)
 
     const res = await this.adapter(url)
     if (res.status !== 200) {
@@ -111,44 +107,33 @@ export class MapBoxGeocoder extends AbstractGeocoder {
     return this.wrapRaw(results, result)
   }
 
-  _formatResult (result) {
-    const context = (result.context || []).reduce((o, item) => {
-      // possible types: country, region, postcode, district, place, locality, neighborhood, address
-      const [type] = item.id.split('.')
-      if (type) {
-        o[type] = item.text
-        if (type === 'country' && item.short_code) {
-          o.countryCode = item.short_code.toUpperCase()
-        }
-      }
-      return o
-    }, {})
-
-    // get main type
-    const [type] = result.id.split('.')
-    if (type) {
-      context[type] = result.text
-    }
-
-    const { properties = {}, address, bbox, id } = result
+  _formatResult(result) {
+    const { properties, id } = result
+    const { context } = properties
 
     const formatted = {
-      formattedAddress: result.place_name,
-      latitude: result.center[1],
-      longitude: result.center[0],
-      country: context.country,
-      countryCode: context.countryCode,
-      state: context.region,
-      city: context.place,
-      zipcode: context.postcode,
-      district: context.district,
-      streetName: type === 'address' ? context.address : undefined,
-      streetNumber: type === 'address' ? address : undefined,
-      neighbourhood: context.neighborhood || context.locality,
+      formattedAddress: properties.full_address,
+      latitude: properties.coordinates.latitude,
+      longitude: properties.coordinates.longitude,
+      country: context.country?.name,
+      countryCode: context.country?.country_code,
+      state: context.region?.name,
+      city: context.place?.name,
+      zipcode: context.postcode?.name,
+      district: context.district?.name,
+      streetName:
+        properties.feature_type === 'address'
+          ? context.address?.street_name
+          : undefined,
+      streetNumber:
+        properties.feature_type === 'address'
+          ? context.address?.address_number
+          : undefined,
+      neighbourhood: context.neighborhood?.name || context.locality?.name,
       extra: {
         id,
-        category: properties.category,
-        bbox
+        bbox: properties.bbox ?? undefined,
+        confidence: properties.match_code?.confidence
       }
     }
 

--- a/test/geocoder/fixtures/mapbox.js
+++ b/test/geocoder/fixtures/mapbox.js
@@ -2,365 +2,331 @@ const m = {
   '135 pilkington avenue, birmingham': {
     query: '135 pilkington avenue, birmingham',
     body: {
-      type: 'FeatureCollection',
-      query: ['1', 'champs', 'élysée', 'paris'],
-      features: [{
-        id: 'address.8526372802334154',
-        type: 'Feature',
-        place_type: ['address'],
-        relevance: 0.861481,
-        properties: {
-          accuracy: 'point'
+      features: [
+        {
+          geometry: {
+            coordinates: [-1.81639, 52.5488],
+            type: 'Point'
+          },
+          id: 'dXJuOm1ieGFkcjoyZTM4NDQzMC02MzY1LTRhYmUtYWFiMi02M2EwMzk5N2QxNWU',
+          properties: {
+            context: {
+              address: {
+                address_number: '135',
+                mapbox_id:
+                  'dXJuOm1ieGFkcjoyZTM4NDQzMC02MzY1LTRhYmUtYWFiMi02M2EwMzk5N2QxNWU',
+                name: '135 Pilkington Avenue',
+                street_name: 'Pilkington Avenue'
+              },
+              country: {
+                country_code: 'GB',
+                country_code_alpha_3: 'GBR',
+                mapbox_id: 'dXJuOm1ieHBsYzpJazg',
+                name: 'United Kingdom',
+                wikidata_id: 'Q145'
+              },
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzpGRVpQ',
+                name: 'West Midlands',
+                wikidata_id: 'Q23124'
+              },
+              place: {
+                mapbox_id: 'dXJuOm1ieHBsYzpvQWhQ',
+                name: 'Sutton Coldfield',
+                wikidata_id: 'Q868196'
+              },
+              postcode: {
+                mapbox_id: 'postcode.1365515715709258',
+                name: 'B72 1LH'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpKRTg',
+                name: 'England',
+                region_code: 'ENG',
+                region_code_full: 'GB-ENG',
+                wikidata_id: 'Q21'
+              },
+              street: {
+                mapbox_id:
+                  'dXJuOm1ieGFkci1zdHI6MmUzODQ0MzAtNjM2NS00YWJlLWFhYjItNjNhMDM5OTdkMTVl',
+                name: 'Pilkington Avenue'
+              }
+            },
+            coordinates: {
+              accuracy: 'rooftop',
+              latitude: 52.5488,
+              longitude: -1.81639,
+              routable_points: [
+                {
+                  latitude: 52.548623,
+                  longitude: -1.816448,
+                  name: 'default'
+                }
+              ]
+            },
+            feature_type: 'address',
+            full_address:
+              '135 Pilkington Avenue, Sutton Coldfield, B72 1LH, United Kingdom',
+            mapbox_id:
+              'dXJuOm1ieGFkcjoyZTM4NDQzMC02MzY1LTRhYmUtYWFiMi02M2EwMzk5N2QxNWU',
+            match_code: {
+              address_number: 'matched',
+              confidence: 'low',
+              country: 'inferred',
+              locality: 'not_applicable',
+              place: 'unmatched',
+              postcode: 'unmatched',
+              region: 'not_applicable',
+              street: 'matched'
+            },
+            name: '135 Pilkington Avenue',
+            name_preferred: '135 Pilkington Avenue',
+            place_formatted: 'Sutton Coldfield, B72 1LH, United Kingdom'
+          },
+          type: 'Feature'
         },
-        text_en: 'Rue Des Champs Élysées',
-        place_name_en: '1 Rue Des Champs Élysées, 94250 Gentilly, France',
-        text: 'Rue Des Champs Élysées',
-        place_name: '1 Rue Des Champs Élysées, 94250 Gentilly, France',
-        center: [2.33955, 48.816295],
-        geometry: {
-          type: 'Point',
-          coordinates: [2.33955, 48.816295]
+        {
+          geometry: {
+            coordinates: [-2.232771, 52.999641],
+            type: 'Point'
+          },
+          id: 'dXJuOm1ieGFkci1pdHA6ZXlKeElqb2lNVE0xSUhCcGJHdHBibWQwYjI0Z1lYWmxiblZsTENCaWFYSnRhVzVuYUdGdElpd2liR2x0YVhRaU9pSXpJaXdpYVc1amJIVmtaVjl0WVhSamFGOWtaWFJoYVd3aU9pSjBjblZsSWl3aWJXOWtaU0k2SW1admNuZGhjbVFpTENKMGVYQmxjeUk2SW1OdmRXNTBjbmtzY21WbmFXOXVMSEJ2YzNSamIyUmxMR1JwYzNSeWFXTjBMSEJzWVdObExHeHZZMkZzYVhSNUxHNWxhV2RvWW05eWFHOXZaQ3hoWkdSeVpYTnpJbjA6MQ',
+          properties: {
+            context: {
+              address: {
+                address_number: '135',
+                mapbox_id:
+                  'dXJuOm1ieGFkci1pdHA6ZXlKeElqb2lNVE0xSUhCcGJHdHBibWQwYjI0Z1lYWmxiblZsTENCaWFYSnRhVzVuYUdGdElpd2liR2x0YVhRaU9pSXpJaXdpYVc1amJIVmtaVjl0WVhSamFGOWtaWFJoYVd3aU9pSjBjblZsSWl3aWJXOWtaU0k2SW1admNuZGhjbVFpTENKMGVYQmxjeUk2SW1OdmRXNTBjbmtzY21WbmFXOXVMSEJ2YzNSamIyUmxMR1JwYzNSeWFXTjBMSEJzWVdObExHeHZZMkZzYVhSNUxHNWxhV2RvWW05eWFHOXZaQ3hoWkdSeVpYTnpJbjA6MQ',
+                name: '135 Pilkington Avenue',
+                street_name: 'Pilkington Avenue'
+              },
+              country: {
+                country_code: 'GB',
+                country_code_alpha_3: 'GBR',
+                mapbox_id: 'dXJuOm1ieHBsYzpJazg',
+                name: 'United Kingdom',
+                wikidata_id: 'Q145'
+              },
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzpFZ1pQ',
+                name: 'Staffordshire',
+                wikidata_id: 'Q23105'
+              },
+              locality: {
+                mapbox_id: 'dXJuOm1ieHBsYzpCNitxVHc',
+                name: 'Newcastle-under-Lyme'
+              },
+              place: {
+                mapbox_id: 'dXJuOm1ieHBsYzplRWhQ',
+                name: 'Newcastle',
+                wikidata_id: 'Q868642'
+              },
+              postcode: {
+                mapbox_id: 'postcode.2490799005834752',
+                name: 'ST5 3RE'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpKRTg',
+                name: 'England',
+                region_code: 'ENG',
+                region_code_full: 'GB-ENG',
+                wikidata_id: 'Q21'
+              },
+              street: {
+                mapbox_id:
+                  'dXJuOm1ieGFkci1zdHItaXRwOmV5SnhJam9pTVRNMUlIQnBiR3RwYm1kMGIyNGdZWFpsYm5WbExDQmlhWEp0YVc1bmFHRnRJaXdpYkdsdGFYUWlPaUl6SWl3aWFXNWpiSFZrWlY5dFlYUmphRjlrWlhSaGFXd2lPaUowY25WbElpd2liVzlrWlNJNkltWnZjbmRoY21RaUxDSjBlWEJsY3lJNkltTnZkVzUwY25rc2NtVm5hVzl1TEhCdmMzUmpiMlJsTEdScGMzUnlhV04wTEhCc1lXTmxMR3h2WTJGc2FYUjVMRzVsYVdkb1ltOXlhRzl2WkN4aFpHUnlaWE56SW4wOjE',
+                name: 'Pilkington Avenue'
+              }
+            },
+            coordinates: {
+              accuracy: 'interpolated',
+              latitude: 52.999641,
+              longitude: -2.232771,
+              routable_points: [
+                {
+                  latitude: 52.999641,
+                  longitude: -2.232771,
+                  name: 'default'
+                }
+              ]
+            },
+            feature_type: 'address',
+            full_address:
+              '135 Pilkington Avenue, Newcastle-under-Lyme, Newcastle, ST5 3RE, United Kingdom',
+            mapbox_id:
+              'dXJuOm1ieGFkci1pdHA6ZXlKeElqb2lNVE0xSUhCcGJHdHBibWQwYjI0Z1lYWmxiblZsTENCaWFYSnRhVzVuYUdGdElpd2liR2x0YVhRaU9pSXpJaXdpYVc1amJIVmtaVjl0WVhSamFGOWtaWFJoYVd3aU9pSjBjblZsSWl3aWJXOWtaU0k2SW1admNuZGhjbVFpTENKMGVYQmxjeUk2SW1OdmRXNTBjbmtzY21WbmFXOXVMSEJ2YzNSamIyUmxMR1JwYzNSeWFXTjBMSEJzWVdObExHeHZZMkZzYVhSNUxHNWxhV2RvWW05eWFHOXZaQ3hoWkdSeVpYTnpJbjA6MQ',
+            match_code: {
+              address_number: 'plausible',
+              confidence: 'low',
+              country: 'inferred',
+              locality: 'unmatched',
+              place: 'unmatched',
+              postcode: 'unmatched',
+              region: 'not_applicable',
+              street: 'matched'
+            },
+            name: '135 Pilkington Avenue',
+            name_preferred: '135 Pilkington Avenue',
+            place_formatted:
+              'Newcastle-under-Lyme, Newcastle, ST5 3RE, United Kingdom'
+          },
+          type: 'Feature'
         },
-        address: '1',
-        context: [{
-          id: 'neighborhood.8281701112046280',
-          text_en: 'Plateau',
-          text: 'Plateau'
-        }, {
-          id: 'postcode.8958023468872490',
-          text_en: '94250',
-          text: '94250'
-        }, {
-          id: 'place.8958023468712040',
-          wikidata: 'Q640102',
-          text_en: 'Gentilly',
-          language_en: 'en',
-          text: 'Gentilly',
-          language: 'en'
-        }, {
-          id: 'region.14749210607497330',
-          wikidata: 'Q90',
-          short_code: 'FR-75',
-          text_en: 'Paris',
-          language_en: 'en',
-          text: 'Paris',
-          language: 'en'
-        }, {
-          id: 'country.19008108158641660',
-          wikidata: 'Q142',
-          short_code: 'fr',
-          text_en: 'France',
-          language_en: 'en',
-          text: 'France',
-          language: 'en'
-        }]
-      }, {
-        id: 'address.4972762713479182',
-        type: 'Feature',
-        place_type: ['address'],
-        relevance: 0.861481,
-        properties: {
-          accuracy: 'point'
-        },
-        text_en: 'Port Des Champs-Élysées',
-        place_name_en: '1 Port Des Champs-Élysées, 75008 Paris, France',
-        text: 'Port Des Champs-Élysées',
-        place_name: '1 Port Des Champs-Élysées, 75008 Paris, France',
-        center: [2.314339, 48.864193],
-        geometry: {
-          type: 'Point',
-          coordinates: [2.314339, 48.864193]
-        },
-        address: '1',
-        context: [{
-          id: 'neighborhood.7123338217329640',
-          wikidata: 'Q3413229',
-          text_en: 'Champs-Élysées',
-          language_en: 'en',
-          text: 'Champs-Élysées',
-          language: 'en'
-        }, {
-          id: 'postcode.12225346547695750',
-          text_en: '75008',
-          text: '75008'
-        }, {
-          id: 'locality.12225346547301010',
-          wikidata: 'Q270230',
-          text_en: '8th arrondissement of Paris',
-          language_en: 'en',
-          text: '8th arrondissement of Paris',
-          language: 'en'
-        }, {
-          id: 'place.14749210607497330',
-          wikidata: 'Q90',
-          short_code: 'FR-75',
-          text_en: 'Paris',
-          language_en: 'en',
-          text: 'Paris',
-          language: 'en'
-        }, {
-          id: 'country.19008108158641660',
-          wikidata: 'Q142',
-          short_code: 'fr',
-          text_en: 'France',
-          language_en: 'en',
-          text: 'France',
-          language: 'en'
-        }]
-      }, {
-        id: 'address.8428062523983924',
-        type: 'Feature',
-        place_type: ['address'],
-        relevance: 0.808593,
-        properties: {
-          accuracy: 'interpolated'
-        },
-        text_en: 'Rue Des Champs Elysées',
-        place_name_en: '1 Rue Des Champs Elysées, 72000 Le Mans, France',
-        text: 'Rue Des Champs Elysées',
-        place_name: '1 Rue Des Champs Elysées, 72000 Le Mans, France',
-        center: [0.18443, 48.001783],
-        geometry: {
-          type: 'Point',
-          coordinates: [0.18443, 48.001783],
-          interpolated: true
-        },
-        address: '1',
-        context: [{
-          id: 'neighborhood.7972247622533990',
-          text_en: 'Patis-Saint-Lazare',
-          text: 'Patis-Saint-Lazare'
-        }, {
-          id: 'postcode.8896316255591600',
-          text_en: '72000',
-          text: '72000'
-        }, {
-          id: 'place.9118363809295480',
-          wikidata: 'Q1476',
-          text_en: 'Le Mans',
-          language_en: 'en',
-          text: 'Le Mans',
-          language: 'en'
-        }, {
-          id: 'region.2070339338781030',
-          wikidata: 'Q12740',
-          short_code: 'FR-72',
-          text_en: 'Sarthe',
-          language_en: 'en',
-          text: 'Sarthe',
-          language: 'en'
-        }, {
-          id: 'country.19008108158641660',
-          wikidata: 'Q142',
-          short_code: 'fr',
-          text_en: 'France',
-          language_en: 'en',
-          text: 'France',
-          language: 'en'
-        }]
-      }, {
-        id: 'neighborhood.7123338217329640',
-        type: 'Feature',
-        place_type: ['neighborhood'],
-        relevance: 0.765071,
-        properties: {
-          wikidata: 'Q3413229'
-        },
-        text_en: 'Champs-Élysées',
-        language_en: 'en',
-        place_name_en: 'Champs-Élysées, 75008, 8th arrondissement of Paris, Paris, France',
-        text: 'Champs-Élysées',
-        language: 'en',
-        place_name: 'Champs-Élysées, 75008, 8th arrondissement of Paris, Paris, France',
-        bbox: [2.29503959459934, 48.8630573835619, 2.32332656211299, 48.8737786602598],
-        center: [2.30473, 48.8678],
-        geometry: {
-          type: 'Point',
-          coordinates: [2.30473, 48.8678]
-        },
-        context: [{
-          id: 'postcode.12225346547695750',
-          text_en: '75008',
-          text: '75008'
-        }, {
-          id: 'locality.12225346547301010',
-          wikidata: 'Q270230',
-          text_en: '8th arrondissement of Paris',
-          language_en: 'en',
-          text: '8th arrondissement of Paris',
-          language: 'en'
-        }, {
-          id: 'place.14749210607497330',
-          wikidata: 'Q90',
-          short_code: 'FR-75',
-          text_en: 'Paris',
-          language_en: 'en',
-          text: 'Paris',
-          language: 'en'
-        }, {
-          id: 'country.19008108158641660',
-          wikidata: 'Q142',
-          short_code: 'fr',
-          text_en: 'France',
-          language_en: 'en',
-          text: 'France',
-          language: 'en'
-        }]
-      }, {
-        id: 'poi.824633777947',
-        type: 'Feature',
-        place_type: ['poi'],
-        relevance: 0.482165,
-        properties: {
-          foursquare: '4adcda09f964a520ea3321e3',
-          address: 'Place du Panthéon',
-          wikidata: 'Q188856',
-          landmark: true,
-          category: 'park',
-          maki: 'picnic-site'
-        },
-        text_en: 'Panthéon',
-        language_en: 'en',
-        place_name_en: 'Panthéon, Place du Panthéon, Paris, 75005, France',
-        text: 'Panthéon',
-        language: 'en',
-        place_name: 'Panthéon, Place du Panthéon, Paris, 75005, France',
-        matching_text: 'Paris',
-        matching_place_name: 'Paris, Place du Panthéon, Paris, 75005, France',
-        center: [2.346348859375, 48.84624503125],
-        geometry: {
-          coordinates: [2.346348859375, 48.84624503125],
-          type: 'Point'
-        },
-        context: [{
-          id: 'neighborhood.8977767122305500',
-          wikidata: 'Q3413213',
-          text_en: 'Sorbonne',
-          language_en: 'en',
-          text: 'Sorbonne',
-          language: 'en'
-        }, {
-          id: 'postcode.10263390772285640',
-          text_en: '75005',
-          text: '75005'
-        }, {
-          id: 'locality.10263390773556950',
-          wikidata: 'Q238723',
-          text_en: '5th arrondissement of Paris',
-          language_en: 'en',
-          text: '5th arrondissement of Paris',
-          language: 'en'
-        }, {
-          id: 'place.14749210607497330',
-          wikidata: 'Q90',
-          short_code: 'FR-75',
-          text_en: 'Paris',
-          language_en: 'en',
-          text: 'Paris',
-          language: 'en'
-        }, {
-          id: 'country.19008108158641660',
-          wikidata: 'Q142',
-          short_code: 'fr',
-          text_en: 'France',
-          language_en: 'en',
-          text: 'France',
-          language: 'en'
-        }]
-      }],
-      attribution: 'NOTICE: © 2021 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https:\u002F\u002Fwww.mapbox.com\u002Fabout\u002Fmaps\u002F). This response and the information it contains may not be retained. POI(s) provided by Foursquare.'
+        {
+          geometry: {
+            coordinates: [-122.009827, 36.964346],
+            type: 'Point'
+          },
+          id: 'dXJuOm1ieGFkci1pdHA6ZXlKeElqb2lNVE0xSUhCcGJHdHBibWQwYjI0Z1lYWmxiblZsTENCaWFYSnRhVzVuYUdGdElpd2liR2x0YVhRaU9pSXpJaXdpYVc1amJIVmtaVjl0WVhSamFGOWtaWFJoYVd3aU9pSjBjblZsSWl3aWJXOWtaU0k2SW1admNuZGhjbVFpTENKMGVYQmxjeUk2SW1OdmRXNTBjbmtzY21WbmFXOXVMSEJ2YzNSamIyUmxMR1JwYzNSeWFXTjBMSEJzWVdObExHeHZZMkZzYVhSNUxHNWxhV2RvWW05eWFHOXZaQ3hoWkdSeVpYTnpJbjA6Mg',
+          properties: {
+            context: {
+              address: {
+                address_number: '135',
+                mapbox_id:
+                  'dXJuOm1ieGFkci1pdHA6ZXlKeElqb2lNVE0xSUhCcGJHdHBibWQwYjI0Z1lYWmxiblZsTENCaWFYSnRhVzVuYUdGdElpd2liR2x0YVhRaU9pSXpJaXdpYVc1amJIVmtaVjl0WVhSamFGOWtaWFJoYVd3aU9pSjBjblZsSWl3aWJXOWtaU0k2SW1admNuZGhjbVFpTENKMGVYQmxjeUk2SW1OdmRXNTBjbmtzY21WbmFXOXVMSEJ2YzNSamIyUmxMR1JwYzNSeWFXTjBMSEJzWVdObExHeHZZMkZzYVhSNUxHNWxhV2RvWW05eWFHOXZaQ3hoWkdSeVpYTnpJbjA6Mg',
+                name: '135 Pilkington Avenue',
+                street_name: 'Pilkington Avenue'
+              },
+              country: {
+                country_code: 'US',
+                country_code_alpha_3: 'USA',
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                wikidata_id: 'Q30'
+              },
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBVHZtN0E',
+                name: 'Santa Cruz County',
+                wikidata_id: 'Q108122'
+              },
+              neighborhood: {
+                alternate: {
+                  mapbox_id: 'dXJuOm1ieHBsYzpBZ2dzN0E',
+                  name: 'Beach Flats'
+                },
+                mapbox_id: 'dXJuOm1ieHBsYzpGbGhNN0E',
+                name: 'Lower Seabright'
+              },
+              place: {
+                mapbox_id: 'dXJuOm1ieHBsYzpFWGtvN0E',
+                name: 'Santa Cruz',
+                wikidata_id: 'Q159232'
+              },
+              postcode: {
+                mapbox_id: 'dXJuOm1ieHBsYzpFczBPN0E',
+                name: '95062'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpCbVRz',
+                name: 'California',
+                region_code: 'CA',
+                region_code_full: 'US-CA',
+                wikidata_id: 'Q99'
+              },
+              street: {
+                mapbox_id:
+                  'dXJuOm1ieGFkci1zdHItaXRwOmV5SnhJam9pTVRNMUlIQnBiR3RwYm1kMGIyNGdZWFpsYm5WbExDQmlhWEp0YVc1bmFHRnRJaXdpYkdsdGFYUWlPaUl6SWl3aWFXNWpiSFZrWlY5dFlYUmphRjlrWlhSaGFXd2lPaUowY25WbElpd2liVzlrWlNJNkltWnZjbmRoY21RaUxDSjBlWEJsY3lJNkltTnZkVzUwY25rc2NtVm5hVzl1TEhCdmMzUmpiMlJsTEdScGMzUnlhV04wTEhCc1lXTmxMR3h2WTJGc2FYUjVMRzVsYVdkb1ltOXlhRzl2WkN4aFpHUnlaWE56SW4wOjI',
+                name: 'Pilkington Avenue'
+              }
+            },
+            coordinates: {
+              accuracy: 'interpolated',
+              latitude: 36.964346,
+              longitude: -122.009827,
+              routable_points: [
+                {
+                  latitude: 36.964346,
+                  longitude: -122.009827,
+                  name: 'default'
+                }
+              ]
+            },
+            feature_type: 'address',
+            full_address:
+              '135 Pilkington Avenue, Santa Cruz, California 95062, United States',
+            mapbox_id:
+              'dXJuOm1ieGFkci1pdHA6ZXlKeElqb2lNVE0xSUhCcGJHdHBibWQwYjI0Z1lYWmxiblZsTENCaWFYSnRhVzVuYUdGdElpd2liR2x0YVhRaU9pSXpJaXdpYVc1amJIVmtaVjl0WVhSamFGOWtaWFJoYVd3aU9pSjBjblZsSWl3aWJXOWtaU0k2SW1admNuZGhjbVFpTENKMGVYQmxjeUk2SW1OdmRXNTBjbmtzY21WbmFXOXVMSEJ2YzNSamIyUmxMR1JwYzNSeWFXTjBMSEJzWVdObExHeHZZMkZzYVhSNUxHNWxhV2RvWW05eWFHOXZaQ3hoWkdSeVpYTnpJbjA6Mg',
+            match_code: {
+              address_number: 'plausible',
+              confidence: 'low',
+              country: 'inferred',
+              locality: 'not_applicable',
+              place: 'unmatched',
+              postcode: 'unmatched',
+              region: 'unmatched',
+              street: 'matched'
+            },
+            name: '135 Pilkington Avenue',
+            name_preferred: '135 Pilkington Avenue',
+            place_formatted: 'Santa Cruz, California 95062, United States'
+          },
+          type: 'Feature'
+        }
+      ],
+      type: 'FeatureCollection'
     },
-    expResults: [{
-      formattedAddress: '1 Rue Des Champs Élysées, 94250 Gentilly, France',
-      latitude: 48.816295,
-      longitude: 2.33955,
-      country: 'France',
-      countryCode: 'FR',
-      state: 'Paris',
-      city: 'Gentilly',
-      zipcode: '94250',
-      district: undefined,
-      streetName: 'Rue Des Champs Élysées',
-      streetNumber: '1',
-      neighbourhood: 'Plateau',
-      extra: {
-        id: 'address.8526372802334154',
-        category: undefined,
-        bbox: undefined
+    expResults: [
+      {
+        formattedAddress:
+          '135 Pilkington Avenue, Sutton Coldfield, B72 1LH, United Kingdom',
+        latitude: 52.5488,
+        longitude: -1.81639,
+        country: 'United Kingdom',
+        countryCode: 'GB',
+        state: 'England',
+        city: 'Sutton Coldfield',
+        zipcode: 'B72 1LH',
+        district: 'West Midlands',
+        streetName: 'Pilkington Avenue',
+        streetNumber: '135',
+        neighbourhood: undefined,
+        extra: {
+          id: 'dXJuOm1ieGFkcjoyZTM4NDQzMC02MzY1LTRhYmUtYWFiMi02M2EwMzk5N2QxNWU',
+          bbox: undefined,
+          confidence: 'low'
+        }
+      },
+      {
+        formattedAddress:
+          '135 Pilkington Avenue, Newcastle-under-Lyme, Newcastle, ST5 3RE, United Kingdom',
+        latitude: 52.999641,
+        longitude: -2.232771,
+        country: 'United Kingdom',
+        countryCode: 'GB',
+        state: 'England',
+        city: 'Newcastle',
+        zipcode: 'ST5 3RE',
+        district: 'Staffordshire',
+        streetName: 'Pilkington Avenue',
+        streetNumber: '135',
+        neighbourhood: 'Newcastle-under-Lyme',
+        extra: {
+          id: 'dXJuOm1ieGFkci1pdHA6ZXlKeElqb2lNVE0xSUhCcGJHdHBibWQwYjI0Z1lYWmxiblZsTENCaWFYSnRhVzVuYUdGdElpd2liR2x0YVhRaU9pSXpJaXdpYVc1amJIVmtaVjl0WVhSamFGOWtaWFJoYVd3aU9pSjBjblZsSWl3aWJXOWtaU0k2SW1admNuZGhjbVFpTENKMGVYQmxjeUk2SW1OdmRXNTBjbmtzY21WbmFXOXVMSEJ2YzNSamIyUmxMR1JwYzNSeWFXTjBMSEJzWVdObExHeHZZMkZzYVhSNUxHNWxhV2RvWW05eWFHOXZaQ3hoWkdSeVpYTnpJbjA6MQ',
+          bbox: undefined,
+          confidence: 'low'
+        }
+      },
+      {
+        formattedAddress:
+          '135 Pilkington Avenue, Santa Cruz, California 95062, United States',
+        latitude: 36.964346,
+        longitude: -122.009827,
+        country: 'United States',
+        countryCode: 'US',
+        state: 'California',
+        city: 'Santa Cruz',
+        zipcode: '95062',
+        district: 'Santa Cruz County',
+        streetName: 'Pilkington Avenue',
+        streetNumber: '135',
+        neighbourhood: 'Lower Seabright',
+        extra: {
+          id: 'dXJuOm1ieGFkci1pdHA6ZXlKeElqb2lNVE0xSUhCcGJHdHBibWQwYjI0Z1lYWmxiblZsTENCaWFYSnRhVzVuYUdGdElpd2liR2x0YVhRaU9pSXpJaXdpYVc1amJIVmtaVjl0WVhSamFGOWtaWFJoYVd3aU9pSjBjblZsSWl3aWJXOWtaU0k2SW1admNuZGhjbVFpTENKMGVYQmxjeUk2SW1OdmRXNTBjbmtzY21WbmFXOXVMSEJ2YzNSamIyUmxMR1JwYzNSeWFXTjBMSEJzWVdObExHeHZZMkZzYVhSNUxHNWxhV2RvWW05eWFHOXZaQ3hoWkdSeVpYTnpJbjA6Mg',
+          bbox: undefined,
+          confidence: 'low'
+        }
       }
-    }, {
-      formattedAddress: '1 Port Des Champs-Élysées, 75008 Paris, France',
-      latitude: 48.864193,
-      longitude: 2.314339,
-      country: 'France',
-      countryCode: 'FR',
-      state: undefined,
-      city: 'Paris',
-      zipcode: '75008',
-      district: undefined,
-      streetName: 'Port Des Champs-Élysées',
-      streetNumber: '1',
-      neighbourhood: 'Champs-Élysées',
-      extra: {
-        id: 'address.4972762713479182',
-        category: undefined,
-        bbox: undefined
-      }
-    }, {
-      formattedAddress: '1 Rue Des Champs Elysées, 72000 Le Mans, France',
-      latitude: 48.001783,
-      longitude: 0.18443,
-      country: 'France',
-      countryCode: 'FR',
-      state: 'Sarthe',
-      city: 'Le Mans',
-      zipcode: '72000',
-      district: undefined,
-      streetName: 'Rue Des Champs Elysées',
-      streetNumber: '1',
-      neighbourhood: 'Patis-Saint-Lazare',
-      extra: {
-        id: 'address.8428062523983924',
-        category: undefined,
-        bbox: undefined
-      }
-    }, {
-      formattedAddress: 'Champs-Élysées, 75008, 8th arrondissement of Paris, Paris, France',
-      latitude: 48.8678,
-      longitude: 2.30473,
-      country: 'France',
-      countryCode: 'FR',
-      state: undefined,
-      city: 'Paris',
-      zipcode: '75008',
-      district: undefined,
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: 'Champs-Élysées',
-      extra: {
-        id: 'neighborhood.7123338217329640',
-        category: undefined,
-        bbox: [2.29503959459934, 48.8630573835619, 2.32332656211299, 48.8737786602598]
-      }
-    }, {
-      formattedAddress: 'Panthéon, Place du Panthéon, Paris, 75005, France',
-      latitude: 48.84624503125,
-      longitude: 2.346348859375,
-      country: 'France',
-      countryCode: 'FR',
-      state: undefined,
-      city: 'Paris',
-      zipcode: '75005',
-      district: undefined,
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: 'Sorbonne',
-      extra: {
-        id: 'poi.824633777947',
-        category: 'park',
-        bbox: undefined
-      }
-    }]
+    ]
   },
   '40.714232,-73.9612889': {
     query: {
@@ -369,514 +335,573 @@ const m = {
     },
     body: {
       type: 'FeatureCollection',
-      query: [-73.9612889, 40.714232],
-      features: [{
-        id: 'address.3679793406555678',
-        type: 'Feature',
-        place_type: ['address'],
-        relevance: 1,
-        properties: {
-          accuracy: 'parcel'
+      features: [
+        {
+          type: 'Feature',
+          id: 'dXJuOm1ieGFkcjo3ODJkZTY1ZS1lZGMxLTRmYTktYjBjOS1kMDg0YjVjM2I0MzI',
+          geometry: {
+            type: 'Point',
+            coordinates: [-73.9613, 40.71426]
+          },
+          properties: {
+            mapbox_id:
+              'dXJuOm1ieGFkcjo3ODJkZTY1ZS1lZGMxLTRmYTktYjBjOS1kMDg0YjVjM2I0MzI',
+            feature_type: 'address',
+            full_address:
+              '277 Bedford Avenue, Brooklyn, New York 11211, United States',
+            name: '277 Bedford Avenue',
+            name_preferred: '277 Bedford Avenue',
+            coordinates: {
+              longitude: -73.9613,
+              latitude: 40.71426,
+              accuracy: 'rooftop',
+              routable_points: [
+                {
+                  name: 'default',
+                  latitude: 40.714304,
+                  longitude: -73.961416
+                }
+              ]
+            },
+            place_formatted: 'Brooklyn, New York 11211, United States',
+            context: {
+              address: {
+                mapbox_id:
+                  'dXJuOm1ieGFkcjo3ODJkZTY1ZS1lZGMxLTRmYTktYjBjOS1kMDg0YjVjM2I0MzI',
+                address_number: '277',
+                street_name: 'Bedford Avenue',
+                name: '277 Bedford Avenue'
+              },
+              street: {
+                mapbox_id:
+                  'dXJuOm1ieGFkci1zdHI6NzgyZGU2NWUtZWRjMS00ZmE5LWIwYzktZDA4NGI1YzNiNDMy',
+                name: 'Bedford Avenue'
+              },
+              neighborhood: {
+                mapbox_id: 'dXJuOm1ieHBsYzpLdnZNN0E',
+                name: 'Williamsburg',
+                wikidata_id: 'Q771572',
+                alternate: {
+                  mapbox_id: 'dXJuOm1ieHBsYzpJLzNzN0E',
+                  name: 'South Side'
+                }
+              },
+              postcode: {
+                mapbox_id: 'postcode.1452927999608038',
+                name: '11211'
+              },
+              locality: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBLzBLN0E',
+                name: 'Brooklyn',
+                wikidata_id: 'Q18419'
+              },
+              place: {
+                mapbox_id: 'dXJuOm1ieHBsYzpEZTVJN0E',
+                name: 'New York',
+                wikidata_id: 'Q60'
+              },
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzp2T2Jz',
+                name: 'Kings County',
+                wikidata_id: 'Q11980692'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBYVRz',
+                name: 'New York',
+                wikidata_id: 'Q1384',
+                region_code: 'NY',
+                region_code_full: 'US-NY'
+              },
+              country: {
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                wikidata_id: 'Q30',
+                country_code: 'US',
+                country_code_alpha_3: 'USA'
+              }
+            }
+          }
         },
-        text_en: 'Bedford Avenue',
-        place_name_en: '277 Bedford Avenue, Brooklyn, New York 11211, United States',
-        text: 'Bedford Avenue',
-        place_name: '277 Bedford Avenue, Brooklyn, New York 11211, United States',
-        center: [-73.961297, 40.714259],
-        geometry: {
-          type: 'Point',
-          coordinates: [-73.961297, 40.714259]
+        {
+          type: 'Feature',
+          id: 'dXJuOm1ieHBsYzpLdnZNN0E',
+          geometry: {
+            type: 'Point',
+            coordinates: [-73.960434, 40.715305]
+          },
+          properties: {
+            mapbox_id: 'dXJuOm1ieHBsYzpLdnZNN0E',
+            feature_type: 'neighborhood',
+            full_address: 'Williamsburg, Brooklyn, New York, United States',
+            name: 'Williamsburg',
+            name_preferred: 'Williamsburg',
+            coordinates: {
+              longitude: -73.960434,
+              latitude: 40.715305
+            },
+            place_formatted: 'Brooklyn, New York, United States',
+            bbox: [-73.969934, 40.698039, -73.941931, 40.725249],
+            context: {
+              postcode: {
+                mapbox_id: 'postcode.1452927999608038',
+                name: '11211'
+              },
+              locality: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBLzBLN0E',
+                name: 'Brooklyn',
+                wikidata_id: 'Q18419'
+              },
+              place: {
+                mapbox_id: 'dXJuOm1ieHBsYzpEZTVJN0E',
+                name: 'New York',
+                wikidata_id: 'Q60'
+              },
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzp2T2Jz',
+                name: 'Kings County',
+                wikidata_id: 'Q11980692'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBYVRz',
+                name: 'New York',
+                wikidata_id: 'Q1384',
+                region_code: 'NY',
+                region_code_full: 'US-NY'
+              },
+              country: {
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                wikidata_id: 'Q30',
+                country_code: 'US',
+                country_code_alpha_3: 'USA'
+              },
+              neighborhood: {
+                mapbox_id: 'dXJuOm1ieHBsYzpLdnZNN0E',
+                name: 'Williamsburg',
+                wikidata_id: 'Q771572'
+              }
+            }
+          }
         },
-        address: '277',
-        context: [{
-          id: 'neighborhood.2102030',
-          text_en: 'Williamsburg',
-          text: 'Williamsburg'
-        }, {
-          id: 'postcode.10441086852103120',
-          text_en: '11211',
-          text: '11211'
-        }, {
-          id: 'locality.6335122455180360',
-          wikidata: 'Q18419',
-          text_en: 'Brooklyn',
-          language_en: 'en',
-          text: 'Brooklyn',
-          language: 'en'
-        }, {
-          id: 'place.2618194975964500',
-          wikidata: 'Q60',
-          text_en: 'New York City',
-          language_en: 'en',
-          text: 'New York City',
-          language: 'en'
-        }, {
-          id: 'district.3780609411998600',
-          wikidata: 'Q11980692',
-          text_en: 'Kings County',
-          language_en: 'en',
-          text: 'Kings County',
-          language: 'en'
-        }, {
-          id: 'region.17349986251855570',
-          wikidata: 'Q1384',
-          short_code: 'US-NY',
-          text_en: 'New York',
-          language_en: 'en',
-          text: 'New York',
-          language: 'en'
-        }, {
-          id: 'country.19678805456372290',
-          wikidata: 'Q30',
-          short_code: 'us',
-          text_en: 'United States',
-          language_en: 'en',
-          text: 'United States',
-          language: 'en'
-        }]
-      }, {
-        id: 'neighborhood.2102030',
-        type: 'Feature',
-        place_type: ['neighborhood'],
-        relevance: 1,
-        properties: {},
-        text_en: 'Williamsburg',
-        place_name_en: 'Williamsburg, New York City, New York 11211, United States',
-        text: 'Williamsburg',
-        place_name: 'Williamsburg, New York City, New York 11211, United States',
-        bbox: [-73.97561, 40.69766, -73.920726, 40.727779],
-        center: [-73.9535, 40.7146],
-        geometry: {
-          type: 'Point',
-          coordinates: [-73.9535, 40.7146]
+        {
+          type: 'Feature',
+          id: 'postcode.1452927999608038',
+          geometry: {
+            type: 'Point',
+            coordinates: [-73.955636, 40.651558]
+          },
+          properties: {
+            mapbox_id: 'postcode.1452927999608038',
+            feature_type: 'postcode',
+            full_address: 'Brooklyn, New York 11211, United States',
+            name: '11211',
+            name_preferred: '11211',
+            coordinates: {
+              longitude: -73.955636,
+              latitude: 40.651558
+            },
+            place_formatted: 'Brooklyn, New York, United States',
+            context: {
+              locality: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBLzBLN0E',
+                name: 'Brooklyn',
+                wikidata_id: 'Q18419'
+              },
+              place: {
+                mapbox_id: 'dXJuOm1ieHBsYzpEZTVJN0E',
+                name: 'New York',
+                wikidata_id: 'Q60'
+              },
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzp2T2Jz',
+                name: 'Kings County',
+                wikidata_id: 'Q11980692'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBYVRz',
+                name: 'New York',
+                wikidata_id: 'Q1384',
+                region_code: 'NY',
+                region_code_full: 'US-NY'
+              },
+              country: {
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                wikidata_id: 'Q30',
+                country_code: 'US',
+                country_code_alpha_3: 'USA'
+              },
+              postcode: {
+                mapbox_id: 'postcode.1452927999608038',
+                name: '11211'
+              }
+            }
+          }
         },
-        context: [{
-          id: 'postcode.10441086852103120',
-          text_en: '11211',
-          text: '11211'
-        }, {
-          id: 'locality.6335122455180360',
-          wikidata: 'Q18419',
-          text_en: 'Brooklyn',
-          language_en: 'en',
-          text: 'Brooklyn',
-          language: 'en'
-        }, {
-          id: 'place.2618194975964500',
-          wikidata: 'Q60',
-          text_en: 'New York City',
-          language_en: 'en',
-          text: 'New York City',
-          language: 'en'
-        }, {
-          id: 'district.3780609411998600',
-          wikidata: 'Q11980692',
-          text_en: 'Kings County',
-          language_en: 'en',
-          text: 'Kings County',
-          language: 'en'
-        }, {
-          id: 'region.17349986251855570',
-          wikidata: 'Q1384',
-          short_code: 'US-NY',
-          text_en: 'New York',
-          language_en: 'en',
-          text: 'New York',
-          language: 'en'
-        }, {
-          id: 'country.19678805456372290',
-          wikidata: 'Q30',
-          short_code: 'us',
-          text_en: 'United States',
-          language_en: 'en',
-          text: 'United States',
-          language: 'en'
-        }]
-      }, {
-        id: 'postcode.10441086852103120',
-        type: 'Feature',
-        place_type: ['postcode'],
-        relevance: 1,
-        properties: {},
-        text_en: '11211',
-        place_name_en: 'Brooklyn, New York 11211, United States',
-        text: '11211',
-        place_name: 'Brooklyn, New York 11211, United States',
-        bbox: [-73.9758746673972, 40.6976445053516, -73.9227090230438, 40.7276899833336],
-        center: [-73.96, 40.71],
-        geometry: {
-          type: 'Point',
-          coordinates: [-73.96, 40.71]
+        {
+          type: 'Feature',
+          id: 'dXJuOm1ieHBsYzpBLzBLN0E',
+          geometry: {
+            type: 'Point',
+            coordinates: [-73.9497, 40.6526]
+          },
+          properties: {
+            mapbox_id: 'dXJuOm1ieHBsYzpBLzBLN0E',
+            feature_type: 'locality',
+            full_address: 'Brooklyn, New York, United States',
+            name: 'Brooklyn',
+            name_preferred: 'Brooklyn',
+            coordinates: {
+              longitude: -73.9497,
+              latitude: 40.6526
+            },
+            place_formatted: 'New York, United States',
+            bbox: [-74.042412, 40.566162, -73.833365, 40.739446],
+            context: {
+              place: {
+                mapbox_id: 'dXJuOm1ieHBsYzpEZTVJN0E',
+                name: 'New York',
+                wikidata_id: 'Q60'
+              },
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzp2T2Jz',
+                name: 'Kings County',
+                wikidata_id: 'Q11980692'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBYVRz',
+                name: 'New York',
+                wikidata_id: 'Q1384',
+                region_code: 'NY',
+                region_code_full: 'US-NY'
+              },
+              country: {
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                wikidata_id: 'Q30',
+                country_code: 'US',
+                country_code_alpha_3: 'USA'
+              },
+              locality: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBLzBLN0E',
+                name: 'Brooklyn',
+                wikidata_id: 'Q18419'
+              }
+            }
+          }
         },
-        context: [{
-          id: 'locality.6335122455180360',
-          wikidata: 'Q18419',
-          text_en: 'Brooklyn',
-          language_en: 'en',
-          text: 'Brooklyn',
-          language: 'en'
-        }, {
-          id: 'place.2618194975964500',
-          wikidata: 'Q60',
-          text_en: 'New York City',
-          language_en: 'en',
-          text: 'New York City',
-          language: 'en'
-        }, {
-          id: 'district.3780609411998600',
-          wikidata: 'Q11980692',
-          text_en: 'Kings County',
-          language_en: 'en',
-          text: 'Kings County',
-          language: 'en'
-        }, {
-          id: 'region.17349986251855570',
-          wikidata: 'Q1384',
-          short_code: 'US-NY',
-          text_en: 'New York',
-          language_en: 'en',
-          text: 'New York',
-          language: 'en'
-        }, {
-          id: 'country.19678805456372290',
-          wikidata: 'Q30',
-          short_code: 'us',
-          text_en: 'United States',
-          language_en: 'en',
-          text: 'United States',
-          language: 'en'
-        }]
-      }, {
-        id: 'locality.6335122455180360',
-        type: 'Feature',
-        place_type: ['locality'],
-        relevance: 1,
-        properties: {
-          wikidata: 'Q18419'
+        {
+          type: 'Feature',
+          id: 'dXJuOm1ieHBsYzpEZTVJN0E',
+          geometry: {
+            type: 'Point',
+            coordinates: [-74.005994, 40.712749]
+          },
+          properties: {
+            mapbox_id: 'dXJuOm1ieHBsYzpEZTVJN0E',
+            feature_type: 'place',
+            full_address: 'New York, New York, United States',
+            name: 'New York',
+            name_preferred: 'New York',
+            coordinates: {
+              longitude: -74.005994,
+              latitude: 40.712749
+            },
+            place_formatted: 'New York, United States',
+            bbox: [-74.25964, 40.477399, -73.700292, 40.917577],
+            context: {
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzp2T2Jz',
+                name: 'Kings County',
+                wikidata_id: 'Q11980692'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBYVRz',
+                name: 'New York',
+                wikidata_id: 'Q1384',
+                region_code: 'NY',
+                region_code_full: 'US-NY'
+              },
+              country: {
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                wikidata_id: 'Q30',
+                country_code: 'US',
+                country_code_alpha_3: 'USA'
+              },
+              place: {
+                mapbox_id: 'dXJuOm1ieHBsYzpEZTVJN0E',
+                name: 'New York',
+                wikidata_id: 'Q60'
+              }
+            }
+          }
         },
-        text_en: 'Brooklyn',
-        language_en: 'en',
-        place_name_en: 'Brooklyn, New York, United States',
-        text: 'Brooklyn',
-        language: 'en',
-        place_name: 'Brooklyn, New York, United States',
-        bbox: [-74.0424119629985, 40.566161483009, -73.833365, 40.739446],
-        center: [-73.9496, 40.6501],
-        geometry: {
-          type: 'Point',
-          coordinates: [-73.9496, 40.6501]
+        {
+          type: 'Feature',
+          id: 'dXJuOm1ieHBsYzp2T2Jz',
+          geometry: {
+            type: 'Point',
+            coordinates: [-73.980562, 40.698253]
+          },
+          properties: {
+            mapbox_id: 'dXJuOm1ieHBsYzp2T2Jz',
+            feature_type: 'district',
+            full_address: 'Kings County, New York, United States',
+            name: 'Kings County',
+            name_preferred: 'Kings County',
+            coordinates: {
+              longitude: -73.980562,
+              latitude: 40.698253
+            },
+            place_formatted: 'New York, United States',
+            bbox: [-74.054951, 40.546429, -73.83361, 40.739633],
+            context: {
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBYVRz',
+                name: 'New York',
+                wikidata_id: 'Q1384',
+                region_code: 'NY',
+                region_code_full: 'US-NY'
+              },
+              country: {
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                wikidata_id: 'Q30',
+                country_code: 'US',
+                country_code_alpha_3: 'USA'
+              },
+              district: {
+                mapbox_id: 'dXJuOm1ieHBsYzp2T2Jz',
+                name: 'Kings County',
+                wikidata_id: 'Q11980692'
+              }
+            }
+          }
         },
-        context: [{
-          id: 'place.2618194975964500',
-          wikidata: 'Q60',
-          text_en: 'New York City',
-          language_en: 'en',
-          text: 'New York City',
-          language: 'en'
-        }, {
-          id: 'district.3780609411998600',
-          wikidata: 'Q11980692',
-          text_en: 'Kings County',
-          language_en: 'en',
-          text: 'Kings County',
-          language: 'en'
-        }, {
-          id: 'region.17349986251855570',
-          wikidata: 'Q1384',
-          short_code: 'US-NY',
-          text_en: 'New York',
-          language_en: 'en',
-          text: 'New York',
-          language: 'en'
-        }, {
-          id: 'country.19678805456372290',
-          wikidata: 'Q30',
-          short_code: 'us',
-          text_en: 'United States',
-          language_en: 'en',
-          text: 'United States',
-          language: 'en'
-        }]
-      }, {
-        id: 'place.2618194975964500',
-        type: 'Feature',
-        place_type: ['place'],
-        relevance: 1,
-        properties: {
-          wikidata: 'Q60'
+        {
+          type: 'Feature',
+          id: 'dXJuOm1ieHBsYzpBYVRz',
+          geometry: {
+            type: 'Point',
+            coordinates: [-75.465247, 42.751211]
+          },
+          properties: {
+            mapbox_id: 'dXJuOm1ieHBsYzpBYVRz',
+            feature_type: 'region',
+            full_address: 'New York, United States',
+            name: 'New York',
+            name_preferred: 'New York',
+            coordinates: {
+              longitude: -75.465247,
+              latitude: 42.751211
+            },
+            place_formatted: 'United States',
+            bbox: [-79.763007, 40.462666, -71.781689, 45.0217],
+            context: {
+              country: {
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                wikidata_id: 'Q30',
+                country_code: 'US',
+                country_code_alpha_3: 'USA'
+              },
+              region: {
+                mapbox_id: 'dXJuOm1ieHBsYzpBYVRz',
+                name: 'New York',
+                wikidata_id: 'Q1384'
+              }
+            }
+          }
         },
-        text_en: 'New York City',
-        language_en: 'en',
-        place_name_en: 'New York City, New York, United States',
-        text: 'New York City',
-        language: 'en',
-        place_name: 'New York City, New York, United States',
-        bbox: [-74.25909, 40.477399, -73.700272, 40.917577],
-        center: [-73.9866, 40.7306],
-        geometry: {
-          type: 'Point',
-          coordinates: [-73.9866, 40.7306]
-        },
-        context: [{
-          id: 'district.3780609411998600',
-          wikidata: 'Q11980692',
-          text_en: 'Kings County',
-          language_en: 'en',
-          text: 'Kings County',
-          language: 'en'
-        }, {
-          id: 'region.17349986251855570',
-          wikidata: 'Q1384',
-          short_code: 'US-NY',
-          text_en: 'New York',
-          language_en: 'en',
-          text: 'New York',
-          language: 'en'
-        }, {
-          id: 'country.19678805456372290',
-          wikidata: 'Q30',
-          short_code: 'us',
-          text_en: 'United States',
-          language_en: 'en',
-          text: 'United States',
-          language: 'en'
-        }]
-      }, {
-        id: 'district.3780609411998600',
-        type: 'Feature',
-        place_type: ['district'],
-        relevance: 1,
-        properties: {
-          wikidata: 'Q11980692'
-        },
-        text_en: 'Kings County',
-        language_en: 'en',
-        place_name_en: 'Kings County, New York, United States',
-        text: 'Kings County',
-        language: 'en',
-        place_name: 'Kings County, New York, United States',
-        bbox: [-74.04191, 40.570153, -73.833614, 40.739258],
-        center: [-73.99, 40.69],
-        geometry: {
-          type: 'Point',
-          coordinates: [-73.99, 40.69]
-        },
-        context: [{
-          id: 'region.17349986251855570',
-          wikidata: 'Q1384',
-          short_code: 'US-NY',
-          text_en: 'New York',
-          language_en: 'en',
-          text: 'New York',
-          language: 'en'
-        }, {
-          id: 'country.19678805456372290',
-          wikidata: 'Q30',
-          short_code: 'us',
-          text_en: 'United States',
-          language_en: 'en',
-          text: 'United States',
-          language: 'en'
-        }]
-      }, {
-        id: 'region.17349986251855570',
-        type: 'Feature',
-        place_type: ['region'],
-        relevance: 1,
-        properties: {
-          wikidata: 'Q1384',
-          short_code: 'US-NY'
-        },
-        text_en: 'New York',
-        language_en: 'en',
-        place_name_en: 'New York, United States',
-        text: 'New York',
-        language: 'en',
-        place_name: 'New York, United States',
-        bbox: [-79.8578350999901, 40.4771391062446, -71.7564918092633, 45.0239286969073],
-        center: [-75.4652471468304, 42.751210955],
-        geometry: {
-          type: 'Point',
-          coordinates: [-75.4652471468304, 42.751210955]
-        },
-        context: [{
-          id: 'country.19678805456372290',
-          wikidata: 'Q30',
-          short_code: 'us',
-          text_en: 'United States',
-          language_en: 'en',
-          text: 'United States',
-          language: 'en'
-        }]
-      }, {
-        id: 'country.19678805456372290',
-        type: 'Feature',
-        place_type: ['country'],
-        relevance: 1,
-        properties: {
-          wikidata: 'Q30',
-          short_code: 'us'
-        },
-        text_en: 'United States',
-        language_en: 'en',
-        place_name_en: 'United States',
-        text: 'United States',
-        language: 'en',
-        place_name: 'United States',
-        bbox: [-179.9, 18.8163608007951, -66.8847646185949, 71.4202919997506],
-        center: [-97.9222112121185, 39.3812661305678],
-        geometry: {
-          type: 'Point',
-          coordinates: [-97.9222112121185, 39.3812661305678]
+        {
+          type: 'Feature',
+          id: 'dXJuOm1ieHBsYzpJdXc',
+          geometry: {
+            type: 'Point',
+            coordinates: [-97.922211, 39.381266]
+          },
+          properties: {
+            mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+            feature_type: 'country',
+            full_address: 'United States',
+            name: 'United States',
+            name_preferred: 'United States',
+            coordinates: {
+              longitude: -97.922211,
+              latitude: 39.381266
+            },
+            bbox: [-179.9, 18.829161, -66.902733, 71.420291],
+            context: {
+              country: {
+                mapbox_id: 'dXJuOm1ieHBsYzpJdXc',
+                name: 'United States',
+                country_code: 'US',
+                country_code_alpha_3: 'USA',
+                wikidata_id: 'Q30'
+              }
+            }
+          }
         }
-      }],
-      attribution: 'NOTICE: © 2021 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https:\u002F\u002Fwww.mapbox.com\u002Fabout\u002Fmaps\u002F). This response and the information it contains may not be retained. POI(s) provided by Foursquare.'
+      ],
+      attribution:
+        'NOTICE: © 2024 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained.'
     },
-    expResults: [{
-      formattedAddress: '277 Bedford Avenue, Brooklyn, New York 11211, United States',
-      latitude: 40.714259,
-      longitude: -73.961297,
-      country: 'United States',
-      countryCode: 'US',
-      state: 'New York',
-      city: 'New York City',
-      zipcode: '11211',
-      district: 'Kings County',
-      streetName: 'Bedford Avenue',
-      streetNumber: '277',
-      neighbourhood: 'Williamsburg',
-      extra: {
-        id: 'address.3679793406555678',
-        category: undefined,
-        bbox: undefined
+    expResults: [
+      {
+        formattedAddress:
+          '277 Bedford Avenue, Brooklyn, New York 11211, United States',
+        latitude: 40.71426,
+        longitude: -73.9613,
+        country: 'United States',
+        countryCode: 'US',
+        state: 'New York',
+        city: 'New York',
+        zipcode: '11211',
+        district: 'Kings County',
+        streetName: 'Bedford Avenue',
+        streetNumber: '277',
+        neighbourhood: 'Williamsburg',
+        extra: {
+          id: 'dXJuOm1ieGFkcjo3ODJkZTY1ZS1lZGMxLTRmYTktYjBjOS1kMDg0YjVjM2I0MzI',
+          bbox: undefined,
+          confidence: undefined
+        }
+      },
+      {
+        formattedAddress: 'Williamsburg, Brooklyn, New York, United States',
+        latitude: 40.715305,
+        longitude: -73.960434,
+        country: 'United States',
+        countryCode: 'US',
+        state: 'New York',
+        city: 'New York',
+        zipcode: '11211',
+        district: 'Kings County',
+        streetName: undefined,
+        streetNumber: undefined,
+        neighbourhood: 'Williamsburg',
+        extra: {
+          id: 'dXJuOm1ieHBsYzpLdnZNN0E',
+          bbox: [-73.969934, 40.698039, -73.941931, 40.725249],
+          confidence: undefined
+        }
+      },
+      {
+        formattedAddress: 'Brooklyn, New York 11211, United States',
+        latitude: 40.651558,
+        longitude: -73.955636,
+        country: 'United States',
+        countryCode: 'US',
+        state: 'New York',
+        city: 'New York',
+        zipcode: '11211',
+        district: 'Kings County',
+        streetName: undefined,
+        streetNumber: undefined,
+        neighbourhood: 'Brooklyn',
+        extra: {
+          id: 'postcode.1452927999608038',
+          bbox: undefined,
+          confidence: undefined
+        }
+      },
+      {
+        formattedAddress: 'Brooklyn, New York, United States',
+        latitude: 40.6526,
+        longitude: -73.9497,
+        country: 'United States',
+        countryCode: 'US',
+        state: 'New York',
+        city: 'New York',
+        zipcode: undefined,
+        district: 'Kings County',
+        streetName: undefined,
+        streetNumber: undefined,
+        neighbourhood: 'Brooklyn',
+        extra: {
+          id: 'dXJuOm1ieHBsYzpBLzBLN0E',
+          bbox: [-74.042412, 40.566162, -73.833365, 40.739446],
+          confidence: undefined
+        }
+      },
+      {
+        formattedAddress: 'New York, New York, United States',
+        latitude: 40.712749,
+        longitude: -74.005994,
+        country: 'United States',
+        countryCode: 'US',
+        state: 'New York',
+        city: 'New York',
+        zipcode: undefined,
+        district: 'Kings County',
+        streetName: undefined,
+        streetNumber: undefined,
+        neighbourhood: undefined,
+        extra: {
+          id: 'dXJuOm1ieHBsYzpEZTVJN0E',
+          bbox: [-74.25964, 40.477399, -73.700292, 40.917577],
+          confidence: undefined
+        }
+      },
+      {
+        formattedAddress: 'Kings County, New York, United States',
+        latitude: 40.698253,
+        longitude: -73.980562,
+        country: 'United States',
+        countryCode: 'US',
+        state: 'New York',
+        city: undefined,
+        zipcode: undefined,
+        district: 'Kings County',
+        streetName: undefined,
+        streetNumber: undefined,
+        neighbourhood: undefined,
+        extra: {
+          id: 'dXJuOm1ieHBsYzp2T2Jz',
+          bbox: [-74.054951, 40.546429, -73.83361, 40.739633],
+          confidence: undefined
+        }
+      },
+      {
+        formattedAddress: 'New York, United States',
+        latitude: 42.751211,
+        longitude: -75.465247,
+        country: 'United States',
+        countryCode: 'US',
+        state: 'New York',
+        city: undefined,
+        zipcode: undefined,
+        district: undefined,
+        streetName: undefined,
+        streetNumber: undefined,
+        neighbourhood: undefined,
+        extra: {
+          id: 'dXJuOm1ieHBsYzpBYVRz',
+          bbox: [-79.763007, 40.462666, -71.781689, 45.0217],
+          confidence: undefined
+        }
+      },
+      {
+        formattedAddress: 'United States',
+        latitude: 39.381266,
+        longitude: -97.922211,
+        country: 'United States',
+        countryCode: 'US',
+        state: undefined,
+        city: undefined,
+        zipcode: undefined,
+        district: undefined,
+        streetName: undefined,
+        streetNumber: undefined,
+        neighbourhood: undefined,
+        extra: {
+          id: 'dXJuOm1ieHBsYzpJdXc',
+          bbox: [-179.9, 18.829161, -66.902733, 71.420291],
+          confidence: undefined
+        }
       }
-    }, {
-      formattedAddress: 'Williamsburg, New York City, New York 11211, United States',
-      latitude: 40.7146,
-      longitude: -73.9535,
-      country: 'United States',
-      countryCode: 'US',
-      state: 'New York',
-      city: 'New York City',
-      zipcode: '11211',
-      district: 'Kings County',
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: 'Williamsburg',
-      extra: {
-        id: 'neighborhood.2102030',
-        category: undefined,
-        bbox: [-73.97561, 40.69766, -73.920726, 40.727779]
-      }
-    }, {
-      formattedAddress: 'Brooklyn, New York 11211, United States',
-      latitude: 40.71,
-      longitude: -73.96,
-      country: 'United States',
-      countryCode: 'US',
-      state: 'New York',
-      city: 'New York City',
-      zipcode: '11211',
-      district: 'Kings County',
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: 'Brooklyn',
-      extra: {
-        id: 'postcode.10441086852103120',
-        category: undefined,
-        bbox: [-73.9758746673972, 40.6976445053516, -73.9227090230438, 40.7276899833336]
-      }
-    }, {
-      formattedAddress: 'Brooklyn, New York, United States',
-      latitude: 40.6501,
-      longitude: -73.9496,
-      country: 'United States',
-      countryCode: 'US',
-      state: 'New York',
-      city: 'New York City',
-      zipcode: undefined,
-      district: 'Kings County',
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: 'Brooklyn',
-      extra: {
-        id: 'locality.6335122455180360',
-        category: undefined,
-        bbox: [-74.0424119629985, 40.566161483009, -73.833365, 40.739446]
-      }
-    }, {
-      formattedAddress: 'New York City, New York, United States',
-      latitude: 40.7306,
-      longitude: -73.9866,
-      country: 'United States',
-      countryCode: 'US',
-      state: 'New York',
-      city: 'New York City',
-      zipcode: undefined,
-      district: 'Kings County',
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: undefined,
-      extra: {
-        id: 'place.2618194975964500',
-        category: undefined,
-        bbox: [-74.25909, 40.477399, -73.700272, 40.917577]
-      }
-    }, {
-      formattedAddress: 'Kings County, New York, United States',
-      latitude: 40.69,
-      longitude: -73.99,
-      country: 'United States',
-      countryCode: 'US',
-      state: 'New York',
-      city: undefined,
-      zipcode: undefined,
-      district: 'Kings County',
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: undefined,
-      extra: {
-        id: 'district.3780609411998600',
-        category: undefined,
-        bbox: [-74.04191, 40.570153, -73.833614, 40.739258]
-      }
-    }, {
-      formattedAddress: 'New York, United States',
-      latitude: 42.751210955,
-      longitude: -75.4652471468304,
-      country: 'United States',
-      countryCode: 'US',
-      state: 'New York',
-      city: undefined,
-      zipcode: undefined,
-      district: undefined,
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: undefined,
-      extra: {
-        id: 'region.17349986251855570',
-        category: undefined,
-        bbox: [-79.8578350999901, 40.4771391062446, -71.7564918092633, 45.0239286969073]
-      }
-    }, {
-      formattedAddress: 'United States',
-      latitude: 39.3812661305678,
-      longitude: -97.9222112121185,
-      country: 'United States',
-      countryCode: undefined,
-      state: undefined,
-      city: undefined,
-      zipcode: undefined,
-      district: undefined,
-      streetName: undefined,
-      streetNumber: undefined,
-      neighbourhood: undefined,
-      extra: {
-        id: 'country.19678805456372290',
-        category: undefined,
-        bbox: [-179.9, 18.8163608007951, -66.8847646185949, 71.4202919997506]
-      }
-    }]
+    ]
   },
   forward: {
     formattedAddress: '1 Rue Des Champs-Élysées, 94250 Gentilly, France',
@@ -898,7 +923,8 @@ const m = {
     }
   },
   reverse: {
-    formattedAddress: '277 Bedford Avenue, Brooklyn, New York 11211, United States',
+    formattedAddress:
+      '277 Bedford Avenue, Brooklyn, New York 11211, United States',
     latitude: 40.71426,
     longitude: -73.9613,
     country: 'United States',
@@ -917,6 +943,6 @@ const m = {
     }
   }
 }
-export default m
 
+export default m
 export const fixtures = m

--- a/test/geocoder/mapbox.spec.js
+++ b/test/geocoder/mapbox.spec.js
@@ -60,7 +60,10 @@ describe('MapBoxGeocoder', function () {
 
       assert.deepStrictEqual(results, [])
 
-      sinon.assert.calledOnceWithExactly(mockedAdapter, 'https://api.mapbox.com/geocoding/v5/mapbox.places/1%20champs%20%C3%A9lys%C3%A9e%20Paris.json?access_token=apiKey')
+      sinon.assert.calledOnceWithExactly(
+        mockedAdapter,
+        'https://api.mapbox.com/search/geocode/v6/forward?q=1%2520champs%2520%25C3%25A9lys%25C3%25A9e%2520Paris&access_token=apiKey'
+      )
     })
 
     it('should throw on error', async function () {
@@ -84,7 +87,8 @@ describe('MapBoxGeocoder', function () {
       const query = '135 pilkington avenue, birmingham'
       const { body, expResults } = fixtures[query]
 
-      const expUrl = 'https://api.mapbox.com/geocoding/v5/mapbox.places/135%20pilkington%20avenue%2C%20birmingham.json?access_token=apiKey'
+      const expUrl =
+        'https://api.mapbox.com/search/geocode/v6/forward?q=135%2520pilkington%2520avenue%252C%2520birmingham&access_token=apiKey'
 
       const mockedAdapter = sinon.stub().returns(
         Promise.resolve({
@@ -105,7 +109,8 @@ describe('MapBoxGeocoder', function () {
     it('should return address when object', async function () {
       const query = '135 pilkington avenue, birmingham'
       const { body, expResults } = fixtures[query]
-      const expUrl = 'https://api.mapbox.com/geocoding/v5/mapbox.places/135%20pilkington%20avenue%2C%20birmingham.json?access_token=apiKey'
+      const expUrl =
+        'https://api.mapbox.com/search/geocode/v6/forward?q=135%252520pilkington%252520avenue%25252C%252520birmingham&access_token=apiKey'
 
       const mockedAdapter = sinon.stub().returns(
         Promise.resolve({
@@ -138,7 +143,10 @@ describe('MapBoxGeocoder', function () {
 
       assert.deepStrictEqual(results, [])
 
-      sinon.assert.calledOnceWithExactly(mockedAdapter, 'https://api.mapbox.com/geocoding/v5/mapbox.places/-73.9612889%2C40.714232.json?access_token=apiKey')
+      sinon.assert.calledOnceWithExactly(
+        mockedAdapter,
+        'https://api.mapbox.com/search/geocode/v6/reverse?longitude=-73.9612889&latitude=40.714232&access_token=apiKey'
+      )
     })
 
     it('should throw on error', async function () {
@@ -161,7 +169,8 @@ describe('MapBoxGeocoder', function () {
     it('should return address', async function () {
       const query = '40.714232,-73.9612889'
       const { body, expResults } = fixtures[query]
-      const expUrl = 'https://api.mapbox.com/geocoding/v5/mapbox.places/-73.9612889%2C40.714232.json?access_token=apiKey'
+      const expUrl =
+        'https://api.mapbox.com/search/geocode/v6/reverse?longitude=-73.9612889&latitude=40.714232&access_token=apiKey'
 
       const mockedAdapter = sinon.stub().returns(
         Promise.resolve({


### PR DESCRIPTION
This changes aim to update the mapbox geocoder to the [API v6](https://docs.mapbox.com/api/search/geocoding/).
In particular, it allows us to retrieve informations about the [confidence level of the geocoding](https://docs.mapbox.com/api/search/geocoding/) that we put in the `extra` field of the return formatted object. 

```ts 
...
extra: {
  id,
  bbox: properties.bbox ?? undefined,
  confidence: properties.match_code?.confidence
}
```

Note we do not have informations about the `category` in the `extra` field since it is related to POI and these have been seperated from the `Geocoding API`. They are now part of the `Search Box API` and it will also be soon deprecated from the v5 Geocoding API (see **Geocoding v5 POI deprecation: https://docs.mapbox.com/api/search/geocoding-v5/). 
I guess anyway that POI is not relevant to geocoding so it makes sense to not have this `category` property in the returned object.